### PR TITLE
트레이너에게 질문 ajax 페이징 처리

### DIFF
--- a/Project/src/main/java/com/koreait/project/yongsoo/command/trainerQnA/GetTrainerQnACommand.java
+++ b/Project/src/main/java/com/koreait/project/yongsoo/command/trainerQnA/GetTrainerQnACommand.java
@@ -20,9 +20,10 @@ public class GetTrainerQnACommand implements CommonMapCommand {
 
 		Map<String, Object> map = model.asMap();
 		int user_no = (int)map.get("user_no");
+		int page_no = (int)map.get("page_no");
 		
 		TrainerQnADao trainerQnADao = sqlSession.getMapper(TrainerQnADao.class);
-		List<Trainer_qnaDto> qnalist = trainerQnADao.getTrainerQnAList(user_no); 
+		List<Trainer_qnaDto> qnalist = trainerQnADao.getTrainerQnAList(page_no, user_no); 
 		int totalQnACount = trainerQnADao.TrainerQnACount(user_no);
 		
 		TrainerDao trainerDao = sqlSession.getMapper(TrainerDao.class);

--- a/Project/src/main/java/com/koreait/project/yongsoo/controller/TrainerQnAController.java
+++ b/Project/src/main/java/com/koreait/project/yongsoo/controller/TrainerQnAController.java
@@ -29,11 +29,14 @@ public class TrainerQnAController {
 	AbstractApplicationContext ctx = new AnnotationConfigApplicationContext(SooAppContext.class);
 	
 	// 트레이너 View 페이지로 이동 시 자동으로 작동할 ajax처리를 위한 메소드
-	@RequestMapping(value="getTrainerQnAList.plitche/{user_no}", method=RequestMethod.GET,
+	@RequestMapping(value="getTrainerQnAList.plitche/{user_no}/page_no/{page_no}", method=RequestMethod.GET,
 					produces="application/json; charset=utf-8")		
 	@ResponseBody
-	public Map<String, Object> getTrainerQnAList(@PathVariable("user_no") int user_no, Model model) {
+	public Map<String, Object> getTrainerQnAList(@PathVariable("user_no") int user_no, 
+												 @PathVariable("page_no") int page_no,
+												 Model model) {
 		model.addAttribute("user_no", user_no);
+		model.addAttribute("page_no", page_no);
 		GetTrainerQnACommand getTrainerQnACommand = ctx.getBean("getTrainerQnACommand", GetTrainerQnACommand.class);
 		return getTrainerQnACommand.execute(sqlSession, model);
 	}

--- a/Project/src/main/java/com/koreait/project/yongsoo/dao/TrainerQnADao.java
+++ b/Project/src/main/java/com/koreait/project/yongsoo/dao/TrainerQnADao.java
@@ -7,7 +7,7 @@ import com.koreait.project.dto.Trainer_qnaDto;
 public interface TrainerQnADao {
 
 	// 트레이너 View페이지로 이동시 자동으로 해당 트레이너에게 달린 질문 목록을 가져오기 위한 메소드
-	public List<Trainer_qnaDto> getTrainerQnAList(int user_no);
+	public List<Trainer_qnaDto> getTrainerQnAList(int page_no, int user_no);
 	// 트레이너 리스트페이지에서 트레이너 디테일 패이지로 이동 시 해당 트레이너에게 달린 질문 개수를 알아내기 위한 메소드
 	public int TrainerQnACount(int user_no);
 	

--- a/Project/src/main/java/com/koreait/project/yongsoo/dao/mapper/trainerQnA.xml
+++ b/Project/src/main/java/com/koreait/project/yongsoo/dao/mapper/trainerQnA.xml
@@ -7,8 +7,13 @@ PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
 	
 	<select id="getTrainerQnAList" parameterType="int" resultType="com.koreait.project.dto.Trainer_qnaDto">
 		SELECT *
-		  FROM TRAINER_QNA
-		 WHERE TRAINER_USER_NO = #{user_no}
+		  FROM (SELECT T1.*, ROWNUM RN
+		        FROM (SELECT *
+		        	  FROM TRAINER_QNA
+		        	  WHERE TRAINER_USER_NO = #{param2}
+		              ORDER BY TRAINER_QNA_NO DESC) T1
+		       )
+		 WHERE RN BETWEEN (#{param1}*10-9) AND (#{param1}*10)
 	</select>
 	<select id="TrainerQnACount" parameterType="int" resultType="int">
 		SELECT COUNT(*)

--- a/Project/src/main/webapp/resources/db/sooTestCase.sql
+++ b/Project/src/main/webapp/resources/db/sooTestCase.sql
@@ -38,5 +38,20 @@ select * from COMMENTS
 select * from photo
 select * from review
 
-		 
+SELECT *
+  FROM (SELECT T1.*, ROWNUM RN
+        FROM (SELECT *
+        	  FROM TRAINER_QNA
+        	  WHERE TRAINER_USER_NO = 10
+              ORDER BY TRAINER_QNA_NO DESC) T1
+       )
+ WHERE RN BETWEEN 11 AND 20
+
+SELECT *
+FROM (SELECT ROWNUM RN, trainer_qna_title, trainer_qna_content
+      FROM TRAINER_QNA 
+      WHERE TRAINER_USER_NO = 10 
+      ORDER BY TRAINER_QNA_NO DESC) T1 
+WHERE T1.RN BETWEEN 3 AND 5
+
 		 

--- a/Project/src/main/webapp/resources/style/soo/trainerDetailPage.css
+++ b/Project/src/main/webapp/resources/style/soo/trainerDetailPage.css
@@ -222,7 +222,8 @@ table > thead > tr > td {
 	text-decoration: none;
 	color: inherit;
 }
-
-
+#qnaPaging a {
+	margin: 0 5px;
+}
 
 


### PR DESCRIPTION
1. 자바 영역을 최소화 하고 페이징 처리할 수 있도록 구현.
(script, jquery, sql을 통해 진행함)
(용이한 페이징 처리르 위하여, 기존에 리스트 목록을 가져오기 위해 user_no(트레이너번호)만 넘겨주던 부분을 사용자가 이동하길 희망하는 페이지 번호까지 넘겨주게 바꿈)
2. 쿼리문에 rownum을 특정 범위 안에서 충족하는 값만 가져오기 위하여 셀프 서브쿼리를 사용함.
3. 차후 한 페이지에 보여주는 질문 개수를 조절하기 위해서는 ajax부분에 success했을때의 조건과, query문에서 계산식이 달라져야함.