### PR TITLE
트레이너 모임 ajax 페이징 처리

### DIFF
--- a/Project/src/main/java/com/koreait/project/yongsoo/command/trainerMeeting/GetTrainerMeetingListCommand.java
+++ b/Project/src/main/java/com/koreait/project/yongsoo/command/trainerMeeting/GetTrainerMeetingListCommand.java
@@ -18,13 +18,14 @@ public class GetTrainerMeetingListCommand implements CommonMapCommand {
 
 		Map<String, Object> map = model.asMap();
 		int user_no = (int)map.get("user_no");
+		int page_no = (int)map.get("meetingPageNo");
 		
 		TrainerMeetingDao trainerMeetingDao = sqlSession.getMapper(TrainerMeetingDao.class);
 		// 총 모임 개수
 		int totalMeetingCount = trainerMeetingDao.totalMeetingCount(user_no);
 		
 		// 모임 리스트
-		List<MeetingTemDto> meetingList = trainerMeetingDao.findMeetings(user_no);
+		List<MeetingTemDto> meetingList = trainerMeetingDao.findMeetings(page_no, user_no);
 		
 		Map<String, Object> result = new HashMap<String, Object>();
 		if (meetingList.size()>0) {

--- a/Project/src/main/java/com/koreait/project/yongsoo/command/trainerQnA/GetTrainerQnACommand.java
+++ b/Project/src/main/java/com/koreait/project/yongsoo/command/trainerQnA/GetTrainerQnACommand.java
@@ -20,7 +20,7 @@ public class GetTrainerQnACommand implements CommonMapCommand {
 
 		Map<String, Object> map = model.asMap();
 		int user_no = (int)map.get("user_no");
-		int page_no = (int)map.get("page_no");
+		int page_no = (int)map.get("qnaPageNo");
 		
 		TrainerQnADao trainerQnADao = sqlSession.getMapper(TrainerQnADao.class);
 		List<Trainer_qnaDto> qnalist = trainerQnADao.getTrainerQnAList(page_no, user_no); 

--- a/Project/src/main/java/com/koreait/project/yongsoo/controller/TrainerMeetingController.java
+++ b/Project/src/main/java/com/koreait/project/yongsoo/controller/TrainerMeetingController.java
@@ -33,11 +33,14 @@ public class TrainerMeetingController {
 	private AbstractApplicationContext ctx = new AnnotationConfigApplicationContext(SooAppContext.class);
 	
 	// 트레이너 디테일 페이지에서 트레이너 모임 리스트를 불러오기 위한 메소드
-	@RequestMapping(value="getTrainerMeetingList.plitche/{user_no}", method=RequestMethod.GET, 
+	@RequestMapping(value="getTrainerMeetingList.plitche/{user_no}/meetingPageNo/{meetingPageNo}", method=RequestMethod.GET, 
 					produces="application/json; charset=utf-8")
 	@ResponseBody
-	public Map<String, Object> getTrainerMeetingList(@PathVariable("user_no") int user_no, Model model) {
+	public Map<String, Object> getTrainerMeetingList(@PathVariable("user_no") int user_no,
+													 @PathVariable("meetingPageNo") int meetingPageNo
+													 , Model model) {
 		model.addAttribute("user_no", user_no);
+		model.addAttribute("meetingPageNo", meetingPageNo);
 		GetTrainerMeetingListCommand getTrainerMeetingListCommand = ctx.getBean("getTrainerMeetingListCommand", GetTrainerMeetingListCommand.class);
 		return getTrainerMeetingListCommand.execute(sqlSession, model);
 	}

--- a/Project/src/main/java/com/koreait/project/yongsoo/controller/TrainerQnAController.java
+++ b/Project/src/main/java/com/koreait/project/yongsoo/controller/TrainerQnAController.java
@@ -29,14 +29,14 @@ public class TrainerQnAController {
 	AbstractApplicationContext ctx = new AnnotationConfigApplicationContext(SooAppContext.class);
 	
 	// 트레이너 View 페이지로 이동 시 자동으로 작동할 ajax처리를 위한 메소드
-	@RequestMapping(value="getTrainerQnAList.plitche/{user_no}/page_no/{page_no}", method=RequestMethod.GET,
+	@RequestMapping(value="getTrainerQnAList.plitche/{user_no}/qnaPageNo/{qnaPageNo}", method=RequestMethod.GET,
 					produces="application/json; charset=utf-8")		
 	@ResponseBody
 	public Map<String, Object> getTrainerQnAList(@PathVariable("user_no") int user_no, 
-												 @PathVariable("page_no") int page_no,
+												 @PathVariable("qnaPageNo") int qnaPageNo,
 												 Model model) {
 		model.addAttribute("user_no", user_no);
-		model.addAttribute("page_no", page_no);
+		model.addAttribute("qnaPageNo", qnaPageNo);
 		GetTrainerQnACommand getTrainerQnACommand = ctx.getBean("getTrainerQnACommand", GetTrainerQnACommand.class);
 		return getTrainerQnACommand.execute(sqlSession, model);
 	}

--- a/Project/src/main/java/com/koreait/project/yongsoo/dao/TrainerMeetingDao.java
+++ b/Project/src/main/java/com/koreait/project/yongsoo/dao/TrainerMeetingDao.java
@@ -10,7 +10,7 @@ import com.koreait.project.yongsoo.dto.TrainerTemDto;
 public interface TrainerMeetingDao {
 
 	// 트레이너가 개설한 모임 정보를 가져오기 위한 메소드
-	public List<MeetingTemDto> findMeetings(int user_no);
+	public List<MeetingTemDto> findMeetings(int page_no, int user_no);
 	// 트레이너 디테일 페이지에서 해당 트레이너의 총 모임 개수를 가지고 오기 위한 메소드
 	public int totalMeetingCount(int user_no);
 	

--- a/Project/src/main/java/com/koreait/project/yongsoo/dao/mapper/trainerMeeting.xml
+++ b/Project/src/main/java/com/koreait/project/yongsoo/dao/mapper/trainerMeeting.xml
@@ -5,15 +5,21 @@ PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
 
 <mapper namespace="com.koreait.project.yongsoo.dao.TrainerMeetingDao">
 	
-	<select id="findMeetings" parameterType="int" resultType="com.koreait.project.yongsoo.dto.MeetingTemDto">
+	<select id="findMeetings" resultType="com.koreait.project.yongsoo.dto.MeetingTemDto">
 		SELECT *
-		  FROM USERS U FULL OUTER JOIN MEETING M 
-		    ON M.USER_NO = U.USER_NO
-		       FULL OUTER JOIN EXERCISE E
-		       ON M.EXERCISE_NO = E.EXERCISE_NO
-		         FULL OUTER JOIN PHOTO P
-		         ON M.meeting_no = P.photo_referer_no
-		 WHERE M.USER_NO = #{user_no}
+		  FROM (SELECT M1.*, ROWNUM RN
+		        FROM (SELECT *
+		              FROM MEETING
+		              WHERE USER_NO = #{param2}
+		              ORDER BY MEETING_NO DESC) M1
+		        ) M2 
+		  	    FULL OUTER JOIN USERS U 
+		        ON M2.USER_NO = U.USER_NO
+		        FULL OUTER JOIN EXERCISE E
+		        ON M2.EXERCISE_NO = E.EXERCISE_NO
+		        FULL OUTER JOIN PHOTO P
+		        ON M2.meeting_no = P.photo_referer_no
+		 WHERE RN BETWEEN (#{param1}*6-5) AND (#{param1}*6)
 	</select>
 	<select id="totalMeetingCount" parameterType="int" resultType="int">
 		SELECT COUNT(*)

--- a/Project/src/main/webapp/WEB-INF/views/yongPage/trainerDetailPage.jsp
+++ b/Project/src/main/webapp/WEB-INF/views/yongPage/trainerDetailPage.jsp
@@ -53,19 +53,31 @@
 		});
 	}
 	
+	
 	/* 트레이너 리스트페이지에서 트레이너 디테일 페이지로 이동시 자동으로 실행 될 함수(모임 리스트 불러오기용) */
+	var meetingPageNo = 1;
 	function getTrainerMeetingList() {
 		var user_no = ${trainerTemDto.user_no};
 		$.ajax ({
-			url: 'getTrainerMeetingList.plitche/' + user_no,
+			url: 'getTrainerMeetingList.plitche/' + user_no + '/meetingPageNo/' + meetingPageNo,
 			type: 'get',
 			dataType: 'json',
 			success: function(responseObj) {
 				if (responseObj.result) {
+					$('#totalMeeting').empty();
 					$('<div>')
 					.append( $('<p>').html('총 :' + responseObj.totalMeetingCount + '개') )
 					.appendTo('#totalMeeting');
+					
 					trainerMeetingListTable(responseObj.meetingList);
+					
+					var meetingPagingHtml = '<a href="#" onclick="preMeetingPage(); return false;"> 이전 </a>';
+					for(let i=1; i<=Math.ceil(responseObj.totalMeetingCount/6); i++) {
+						meetingPagingHtml += '<a href="#" onclick="changeMeetingPage(' + i + ') ; return false;">' + i + '</a>'; 
+					}
+					meetingPagingHtml += '<a href="#" onclick="nextMeetingPage('+Math.ceil(responseObj.totalMeetingCount/6)+'); return false;"> 다음 </a>';
+					$('#trainerMeetingFooter').html(meetingPagingHtml);
+					
 				} else {
 					$('<div>')
 					.append( $('<p>').html('등록된 모임 정보가 없습니다.') )
@@ -74,6 +86,28 @@
 			},
 			error: function(){alert('실패');}
 		});
+	}
+	
+	/* 모임 페이징 숫자 클릭시 해당 페이징에 맞게 이동할 function */
+	function changeMeetingPage(goMeetingPage_no) {
+		meetingPageNo = goMeetingPage_no;
+		getTrainerMeetingList();
+	}
+	
+	/* 모임 페이지 이전 클릭시 처리할 function */
+	function preMeetingPage() {
+		if (meetingPageNo != 1) {
+			meetingPageNo -= 1;
+		}
+		getTrainerMeetingList();
+	}
+	
+	/* 모임 페이지 다음 클릭시 처리할 function */
+	function nextMeetingPage(lastMeetingPage) {
+		if (meetingPageNo != lastMeetingPage) {
+			meetingPageNo += 1;
+		}
+		getTrainerMeetingList();
 	}
 	
 	/* 트레이너 모임 리스트의 제목이나 내용을 클릭하면 모임 View페이지로 이동할 함수 */
@@ -313,12 +347,12 @@
 		openQnAPopUp();
 	});
 	
-	var page_no = 1;
+	var qnaPageNo = 1;
 	// 해당 트레이너에게 달린 질문 data를 append하는 서브함수
 	function trainerQnAListTable(list, trainerInfo) {
 		$('#qnaList').empty();
 		$('#currentPage').empty();
-		$('#currentPage').text('현재 ' +  page_no  + ' 페이지');
+		$('#currentPage').text('현재 ' +  qnaPageNo  + ' 페이지');
 		$.each(list, function(idx, qna){
 			if (qna.is_answered==0) {
 				$('<tr>')
@@ -348,7 +382,7 @@
 		var user_no = ${trainerTemDto.user_no}
 
 		$.ajax ({
-			url: 'getTrainerQnAList.plitche/'+user_no+'/page_no/'+page_no,
+			url: 'getTrainerQnAList.plitche/'+user_no+'/qnaPageNo/'+qnaPageNo,
 			type: 'get',
 			dataType: 'json',
 			success: function(responseObj) {
@@ -360,13 +394,13 @@
 					
 					trainerQnAListTable(responseObj.qnaList, responseObj.trainerTemDto);
 					
-					var qnaTfoot = '<a href="#" onclick="preQnAPage(); return false;"> 이전 </a>';
+					var qnaPagingHtml = '<a href="#" onclick="preQnAPage(); return false;"> 이전 </a>';
 					for(let i=1; i<=Math.ceil(responseObj.totalQnACount/10); i++) {
-						qnaTfoot += '<a href="#" onclick="changeQnAPage(' + i + ') ; return false;">' + i + '</a>'; 
+						qnaPagingHtml += '<a href="#" onclick="changeQnAPage(' + i + ') ; return false;">' + i + '</a>'; 
 					}
-					qnaTfoot += '<a href="#" onclick="nextchangeQnAPage('+Math.ceil(responseObj.totalQnACount/10)+'); return false;"> 다음 </a>';
+					qnaPagingHtml += '<a href="#" onclick="nextQnAPage('+Math.ceil(responseObj.totalQnACount/10)+'); return false;"> 다음 </a>';
 					$('#qnaPaging').empty();
-					$('#qnaPaging').html(qnaTfoot);
+					$('#qnaPaging').html(qnaPagingHtml);
 				} else {
 					$('<tr>')
 					.append( $('<td colspan="6">').html('등록된 질문이 없습니다. 첫 번째 질문을 등록해 주세요.') )
@@ -378,23 +412,23 @@
 	}
 
 	/* 질문 페이지 숫자 클릭시 처리할 function */
-	function changeQnAPage(goPage_no) {
-		page_no = goPage_no;
+	function changeQnAPage(goQnaPage_no) {
+		qnaPageNo = goQnaPage_no;
 		getTrainerQnAList();
 	}
 	
 	/* 질문 페이지 이전 클릭시 처리할 function */
 	function preQnAPage() {
-		if (page_no != 1) {
-			page_no -= 1;
+		if (qnaPageNo != 1) {
+			qnaPageNo -= 1;
 		}
 		getTrainerQnAList();
 	}
 	
 	/* 질문 페이지 다음 클릭시 처리할 function */
-	function nextchangeQnAPage(lastPage) {
-		if (page_no != lastPage) {
-			page_no += 1;
+	function nextQnAPage(lastQnaPage) {
+		if (qnaPageNo != lastQnaPage) {
+			qnaPageNo += 1;
 		}
 		getTrainerQnAList();
 	}
@@ -445,7 +479,7 @@
 				success: function(responseObj) {
 					if (responseObj.result) {
 						alert('질문이 등록되었습니다.');
-						page_no=1;
+						qnaPageNo=1;
 						getTrainerQnAList();
 					} else {
 						alert('등록을 등록하지 못했습니다.');
@@ -595,6 +629,7 @@
 		</c:if>
 		<div id="totalMeeting"></div>
 		<div id="trainerMeetingList"></div>
+		<div id="trainerMeetingFooter" style=""></div>
 	</div>
 	
 	<div id="reviewList" class="conBox">

--- a/Project/src/main/webapp/resources/db/sooTestCase.sql
+++ b/Project/src/main/webapp/resources/db/sooTestCase.sql
@@ -15,6 +15,11 @@ INSERT INTO TRAINER_INFO values (1, 10, 3, '김철수', '트레이너자격증',
 INSERT INTO TRAINER_INFO values (2, 11, 4, '곽영희', '트레이너자격증', '홍대센터', '안녕하세요. 반갑습니다. 잘부탁드립니다.', SYSDATE);
 INSERT INTO TRAINER_INFO values (3, 12, 5, '박진희', '트레이너자격증', '합정센터', '안녕하세요. 반갑습니다. 잘부탁드립니다.', SYSDATE);
 
+-- 임시 모임(meeting) 3개 
+INSERT INTO MEETING values (5, 11, 10, 6, 0, SYSDATE, SYSDATE, SYSDATE, SYSDATE, 0, 1, '족구합시다.', '족구하면 얼마나 좋게요~!? 다같이 합시다.', 0, null, 0, null, 0);
+INSERT INTO MEETING values (6, 12, 8, 4, 3, SYSDATE, SYSDATE, SYSDATE, SYSDATE, 0, 1, '볼링합시다.', '볼링하면 얼마나 좋게요~!? 다같이 합시다.', 0, null, 0, null, 0);
+INSERT INTO MEETING values (7, 13, 12, 10, 1, SYSDATE, SYSDATE, SYSDATE, SYSDATE, 0, 1, '축구합시다.', '축구하면 얼마나 좋게요~!? 다같이 합시다.', 0, null, 0, null, 0);
+
 -- 임시 모임 참가자 테이블 테스트케이스 
 INSERT INTO MEETING_PARTICIPANTS VALUES (1, 1, 30, SYSDATE, 1, null);
 INSERT INTO MEETING_PARTICIPANTS VALUES (2, 1, 31, SYSDATE, 1, null);
@@ -53,5 +58,25 @@ FROM (SELECT ROWNUM RN, trainer_qna_title, trainer_qna_content
       WHERE TRAINER_USER_NO = 10 
       ORDER BY TRAINER_QNA_NO DESC) T1 
 WHERE T1.RN BETWEEN 3 AND 5
+
+
+
+
+SELECT *
+  FROM (SELECT M1.*, ROWNUM RN
+        FROM (SELECT *
+              FROM MEETING
+              WHERE USER_NO = 10
+              ORDER BY MEETING_NO DESC) M1
+        ) M2 
+  	    FULL OUTER JOIN USERS U 
+        ON M2.USER_NO = U.USER_NO
+        FULL OUTER JOIN EXERCISE E
+        ON M2.EXERCISE_NO = E.EXERCISE_NO
+        FULL OUTER JOIN PHOTO P
+        ON M2.meeting_no = P.photo_referer_no
+ WHERE RN = 1
+
+
 
 		 

--- a/Project/src/main/webapp/resources/style/soo/trainerDetailPage.css
+++ b/Project/src/main/webapp/resources/style/soo/trainerDetailPage.css
@@ -67,7 +67,7 @@
 }
 
 /* tap에서 모임 탭의 css */
-#trainerMeetingList a {
+#trainerMeetingList > a {
 	text-decoration: none;
 	color: inherit;	
 	float: left;


### PR DESCRIPTION
1. 자바 영역을 최소화 하고 페이징 처리할 수 있도록 구현.
(script, jquery, sql을 통해 진행함)
(용이한 페이징 처리르 위하여, 기존에 리스트 목록을 가져오기 위해 user_no(트레이너번호)만 넘겨주던 부분을 사용자가 이동하길 희망하는 페이지 번호까지 넘겨주게 바꿈)
2. 쿼리문에 rownum을 특정 범위 안에서 충족하는 값만 가져오기 위하여 셀프 서브쿼리를 사용함.
3. 차후 한 페이지에 보여주는 질문 개수를 조절하기 위해서는 ajax부분에 success했을때의 조건과, query문에서 계산식이 달라져야함.
4. 개선점 : 보고 싶은 상세 모임을 클릭하였다가 다시 되돌아 왔을 때 무조건 첫 페이징 번호로 돌아오게 되어있음
(보고 있던 페이지 번호로 돌아올 수 있는 방법 찾아보기)