### PR TITLE
2021.02.14 저녁 작업

### DIFF
--- a/Project/src/main/java/com/koreait/project/yongsoo/command/Scrap/InsertScrapCommand.java
+++ b/Project/src/main/java/com/koreait/project/yongsoo/command/Scrap/InsertScrapCommand.java
@@ -1,0 +1,42 @@
+package com.koreait.project.yongsoo.command.Scrap;
+
+import java.sql.Date;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.apache.ibatis.session.SqlSession;
+import org.springframework.ui.Model;
+
+import com.koreait.project.common.CommonMapCommand;
+import com.koreait.project.dto.ScrapDto;
+import com.koreait.project.yongsoo.dao.TrainerMeetingDao;
+
+public class InsertScrapCommand implements CommonMapCommand {
+
+	@Override
+	public Map<String, Object> execute(SqlSession sqlSession, Model model) {
+
+		Map<String, Object> map = model.asMap();
+		ScrapDto scrapDto = (ScrapDto)map.get("scrapDto");
+		int user_no = scrapDto.getUser_no();
+		int scrap_referer_no = scrapDto.getScrap_referer_no();
+
+		TrainerMeetingDao trainerMeetingDao = sqlSession.getMapper(TrainerMeetingDao.class);
+		
+		// 전달받은 모임 번호를 통해 end_date를 구하기 위한 dao호출
+		Date end_gather_date = trainerMeetingDao.getEndGatherDate(scrap_referer_no);
+		// end_date를 구한 데이터를 포함하여 모든 내용을 스크랩 테이블에 insert dao호출
+		int scrapResult = trainerMeetingDao.insertScrap(user_no, scrap_referer_no, end_gather_date);
+		
+		Map<String, Object> result = new HashMap<String, Object>();
+		
+		if (scrapResult>0) {
+			result.put("result", true);
+		} else {
+			result.put("result", false);
+		}
+		
+		return result;
+	}
+
+}

--- a/Project/src/main/java/com/koreait/project/yongsoo/command/Scrap/IsInWishListCommand.java
+++ b/Project/src/main/java/com/koreait/project/yongsoo/command/Scrap/IsInWishListCommand.java
@@ -1,0 +1,35 @@
+package com.koreait.project.yongsoo.command.Scrap;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.apache.ibatis.session.SqlSession;
+import org.springframework.ui.Model;
+
+import com.koreait.project.common.CommonMapCommand;
+import com.koreait.project.yongsoo.dao.TrainerMeetingDao;
+
+public class IsInWishListCommand implements CommonMapCommand {
+
+	@Override
+	public Map<String, Object> execute(SqlSession sqlSession, Model model) {
+
+		Map<String, Object> map = model.asMap();
+		int user_no = (int)map.get("user_no");
+		int meeting_no = (int)map.get("meeting_no");
+		
+		TrainerMeetingDao trainerMeetingDao = sqlSession.getMapper(TrainerMeetingDao.class);
+		int wishResult = trainerMeetingDao.isInWishList(user_no, meeting_no);
+		
+		Map<String, Object> result = new HashMap<String, Object>();
+		
+		if (wishResult>0) {
+			result.put("result", true);
+		} else {
+			result.put("result", false);
+		}
+		
+		return result;
+	}
+
+}

--- a/Project/src/main/java/com/koreait/project/yongsoo/command/qna/GetQnAListCommand.java
+++ b/Project/src/main/java/com/koreait/project/yongsoo/command/qna/GetQnAListCommand.java
@@ -65,7 +65,7 @@ public class GetQnAListCommand implements CommonVoidCommand {
 				totalRecord = commonQnADao.getIsSolvedQnACount(filter_no);
 				endRecord = endRecord < totalRecord ? endRecord : totalRecord;
 				qnaList = commonQnADao.getIsSolvedQnAList(filter_no, beginRecord, endRecord);
-				paging = Paging.getPaging("goQnAPageWithFilter.plitche?filter_no="+filter_no, totalRecord, recordPerPage, page);
+				paging = Paging.getPaging("goQnAPage.plitche?filter_no="+filter_no, totalRecord, recordPerPage, page);
 			}
 		} else {
 			switch(searchCategory) {

--- a/Project/src/main/java/com/koreait/project/yongsoo/command/trainer/GoTrainerListCommand.java
+++ b/Project/src/main/java/com/koreait/project/yongsoo/command/trainer/GoTrainerListCommand.java
@@ -16,14 +16,17 @@ public class GoTrainerListCommand implements CommonVoidCommand {
 
 		TrainerDao trainerDao = sqlSession.getMapper(TrainerDao.class);
 		List<TrainerTemDto> trainerList = trainerDao.trainerList();
-
+		
+		
 		for (int i=0; i<trainerList.size(); i++) {
 			int user_no = trainerList.get(i).getUser_no();
 			
 			if (trainerDao.trainerScore(user_no)==null) {
 				trainerList.get(i).setScore(0.0);
 			} else {
-				trainerList.get(i).setScore(trainerDao.trainerScore(user_no));
+				double score = trainerDao.trainerScore(user_no);
+				score = Math.round(score*100);
+				trainerList.get(i).setScore(score/100);
 			}
 			
 			trainerList.get(i).setReviews(trainerDao.reviewCount(user_no));

--- a/Project/src/main/java/com/koreait/project/yongsoo/command/trainerMeeting/CreateMeetingCommand.java
+++ b/Project/src/main/java/com/koreait/project/yongsoo/command/trainerMeeting/CreateMeetingCommand.java
@@ -1,7 +1,7 @@
 package com.koreait.project.yongsoo.command.trainerMeeting;
 
 import java.io.File;
-import java.sql.Timestamp;
+import java.sql.Date;
 import java.util.Map;
 
 import org.apache.ibatis.session.SqlSession;
@@ -23,9 +23,9 @@ public class CreateMeetingCommand{
 		int user_no = Integer.parseInt(multipartRequest.getParameter("user_no"));
 		String meeting_title = multipartRequest.getParameter("meeting_title");
 		String meeting_content = multipartRequest.getParameter("meeting_content");
-		Timestamp meeting_date = Timestamp.valueOf(multipartRequest.getParameter("meeting_date"));
-		Timestamp start_gather_date = Timestamp.valueOf(multipartRequest.getParameter("start_gather_date"));
-		Timestamp end_gather_date = Timestamp.valueOf(multipartRequest.getParameter("end_gather_date"));
+		Date meeting_date = Date.valueOf(multipartRequest.getParameter("meeting_date"));
+		Date start_gather_date = Date.valueOf(multipartRequest.getParameter("start_gather_date"));
+		Date end_gather_date = Date.valueOf(multipartRequest.getParameter("end_gather_date"));
 		int meeting_max = Integer.parseInt(multipartRequest.getParameter("meeting_max"));
 		int meeting_min = Integer.parseInt(multipartRequest.getParameter("meeting_min"));
 		int exercise_no = Integer.parseInt(multipartRequest.getParameter("exercise_no"));

--- a/Project/src/main/java/com/koreait/project/yongsoo/command/trainerMeeting/GoMeetingViewCommand.java
+++ b/Project/src/main/java/com/koreait/project/yongsoo/command/trainerMeeting/GoMeetingViewCommand.java
@@ -32,14 +32,14 @@ public class GoMeetingViewCommand implements CommonVoidCommand {
 		int user_no = createNewMeetingDto.getUser_no();
 		
 		List<MaterialsDto> materialList = trainerMeetingDao.findMaterialsInfo(meeting_no); // 2번
-		
 		TrainerTemDto trainerTemDto = trainerMeetingDao.findUserInfo(user_no); // 3번
-		List<String> interestList = trainerMeetingDao.getUserInterest(user_no); //4번
+		List<String> interestList = trainerMeetingDao.getUserInterest(user_no); // 4번
 		
 		model.addAttribute("meetingDto", createNewMeetingDto);
 		model.addAttribute("materialList", materialList);
 		model.addAttribute("trainerTemDto", trainerTemDto);
 		model.addAttribute("interestList", interestList);
+		model.addAttribute("fromWhere", "trainer");
 		
 		
 	}

--- a/Project/src/main/java/com/koreait/project/yongsoo/config/SooAppContext.java
+++ b/Project/src/main/java/com/koreait/project/yongsoo/config/SooAppContext.java
@@ -3,6 +3,8 @@ package com.koreait.project.yongsoo.config;
 import org.springframework.beans.factory.annotation.Configurable;
 import org.springframework.context.annotation.Bean;
 
+import com.koreait.project.yongsoo.command.Scrap.InsertScrapCommand;
+import com.koreait.project.yongsoo.command.Scrap.IsInWishListCommand;
 import com.koreait.project.yongsoo.command.meetingComment.AddCommentCommand;
 import com.koreait.project.yongsoo.command.meetingComment.DeleteCommentCommand;
 import com.koreait.project.yongsoo.command.meetingComment.GetCommentListCommand;
@@ -187,6 +189,16 @@ public class SooAppContext {
 	@Bean
 	public GoUpdateQnAPageCommand goUpdateQnAPageCommand() {
 		return new GoUpdateQnAPageCommand();
+	}
+	
+	@Bean
+	public IsInWishListCommand isInWishListCommand() {
+		return new IsInWishListCommand();
+	}
+	
+	@Bean
+	public InsertScrapCommand insertScrapCommand() {
+		return new InsertScrapCommand();
 	}
 	
 }

--- a/Project/src/main/java/com/koreait/project/yongsoo/controller/TrainerMeetingController.java
+++ b/Project/src/main/java/com/koreait/project/yongsoo/controller/TrainerMeetingController.java
@@ -17,6 +17,11 @@ import org.springframework.web.bind.annotation.ResponseBody;
 import org.springframework.web.multipart.MultipartHttpServletRequest;
 
 import com.koreait.project.dto.MeetingDto;
+import com.koreait.project.dto.ScrapDto;
+import com.koreait.project.jungho.command.TrainerClassCommand.TrainerClassDeleteCommand;
+import com.koreait.project.jungho.config.JungAppContext;
+import com.koreait.project.yongsoo.command.Scrap.InsertScrapCommand;
+import com.koreait.project.yongsoo.command.Scrap.IsInWishListCommand;
 import com.koreait.project.yongsoo.command.trainerMeeting.CreateMeetingCommand;
 import com.koreait.project.yongsoo.command.trainerMeeting.GetOtherHostMeetingCommand;
 import com.koreait.project.yongsoo.command.trainerMeeting.GetOtherMeetingCommand;
@@ -31,6 +36,7 @@ public class TrainerMeetingController {
 	@Autowired
 	private SqlSession sqlSession;
 	private AbstractApplicationContext ctx = new AnnotationConfigApplicationContext(SooAppContext.class);
+	private AbstractApplicationContext ctx2 = new AnnotationConfigApplicationContext(JungAppContext.class);
 	
 	// 트레이너 디테일 페이지에서 트레이너 모임 리스트를 불러오기 위한 메소드
 	@RequestMapping(value="getTrainerMeetingList.plitche/{user_no}/meetingPageNo/{meetingPageNo}", method=RequestMethod.GET, 
@@ -54,6 +60,29 @@ public class TrainerMeetingController {
 		return "yongPage/meetingViewPage";
 	}
 	
+	// 모임 상세 페이지로 이동 시 현재 로그인 되어있는 사람이 스크랩 한 모임인지 판단하기 위한 메소드
+	@RequestMapping(value="isInWishList.plitche/{user_no}/meeting_no/{meeting_no}", method=RequestMethod.GET,
+					produces="application/json; charset=utf-8")
+	@ResponseBody
+	public Map<String, Object> isInWishList(@PathVariable("user_no") int user_no,
+											@PathVariable("meeting_no") int meeting_no,
+											Model model) {
+		model.addAttribute("user_no", user_no);
+		model.addAttribute("meeting_no", meeting_no);
+		IsInWishListCommand isInWishListCommand = ctx.getBean("isInWishListCommand", IsInWishListCommand.class);
+		return isInWishListCommand.execute(sqlSession, model); 
+	}
+	
+	// 관심 모임으로 등록하기 버튼 클릭시 insert 해주기위한 메소드
+	@RequestMapping(value="addToWishList.plitche", method=RequestMethod.POST,
+					produces="application/json; charset=utf-8")
+	@ResponseBody
+	public Map<String, Object> addToWishList(@RequestBody ScrapDto scrapDto, Model model) {
+		model.addAttribute("scrapDto", scrapDto);
+		InsertScrapCommand insertScrapCommand = ctx.getBean("insertScrapCommand", InsertScrapCommand.class);
+		return insertScrapCommand.execute(sqlSession, model);
+	}
+	
 	// 트레이너 프로그램 등록 - 미팅(모임) 게시글 작성 페이지로 단순이동을 위한 메소드
 	@RequestMapping(value="goCreateMeetingPage.plitche")
 	public String goCreateMeetingPage() {
@@ -67,6 +96,17 @@ public class TrainerMeetingController {
 		CreateMeetingCommand createMeetingCommand = ctx.getBean("createMeetingCommand", CreateMeetingCommand.class);
 		int user_no = createMeetingCommand.execute(sqlSession, model);
 		return "redirect:goTrainerDetail.plitche?user_no=" + user_no;
+	}
+
+	// 모임 View페이지에서 삭제하기 버튼 클릭 시 작동할 메소드
+	@RequestMapping(value="TrainerClassDelete.plitche", method=RequestMethod.POST)
+	public String TrainerClassViewDelete(@RequestParam("meeting_no") int meeting_no,
+										 @RequestParam("user_no") int user_no,
+										 Model model) {
+		model.addAttribute("meeting_no", meeting_no);
+		TrainerClassDeleteCommand trainerClassDeletCommand = ctx2.getBean("trainerClassDeleteCommand", TrainerClassDeleteCommand.class);
+		trainerClassDeletCommand.execute(sqlSession, model);
+		return "redirect:goTrainerDetail.plitche?user_no="+user_no;
 	}
 	
 	// 트레이너 모임 View페이지로 이동 시 호스트의 다른 모임 정보를 불러오기 위한 메소드

--- a/Project/src/main/java/com/koreait/project/yongsoo/dao/TrainerMeetingDao.java
+++ b/Project/src/main/java/com/koreait/project/yongsoo/dao/TrainerMeetingDao.java
@@ -1,5 +1,6 @@
 package com.koreait.project.yongsoo.dao;
 
+import java.sql.Date;
 import java.util.List;
 
 import com.koreait.project.dto.MaterialsDto;
@@ -23,6 +24,14 @@ public interface TrainerMeetingDao {
 	public TrainerTemDto findUserInfo(int user_no);
 	// 4. 모임 개설자의 관심 종목을 가져오기 위한 메소드
 	public List<String> getUserInterest(int user_no);
+	
+	// 이동하는 모임이 이미 스크랩 한 모임인지 판단하기 위한 메소드
+	public int isInWishList(int user_no, int meeting_no);
+	
+	// 전달받은 모임 번호를 통해 end_gather_date를 구하는 메소드
+	public Date getEndGatherDate(int scrap_referer_no);
+	// 모임 view페이지에서 관심모임으로 등록하기 버튼 클릭 시 insert해주기 위한 메소드
+	public int insertScrap(int user_no, int scrap_referer_no, Date end_gather_date);
 	
 	// 트레이너 모임 개설 페이지에서 meeting테이블에 insert를 하기위한 메소드
 	public int createMeeting(CreateNewMeetingDto createNewMeetingDto);

--- a/Project/src/main/java/com/koreait/project/yongsoo/dao/mapper/trainerMeeting.xml
+++ b/Project/src/main/java/com/koreait/project/yongsoo/dao/mapper/trainerMeeting.xml
@@ -71,6 +71,26 @@ PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
 		    ON U.EXERCISE_NO = E.EXERCISE_NO
 		 WHERE U.USER_NO = #{user_no}
 	</select>
+
+ 	
+ 	<select id="isInWishList" resultType="int">
+ 		SELECT COUNT(*)
+ 		  FROM SCRAP
+ 		 WHERE USER_NO = #{param1}
+ 		   AND SCRAP_REFERER_NO = #{param2}
+ 	</select>
+ 	
+ 	<select id="getEndGatherDate" parameterType="int" resultType="java.sql.Date">
+ 		SELECT END_GATHER_DATE
+ 		  FROM MEETING
+ 		 WHERE MEETING_NO = #{scrap_referer_no}
+ 	</select>
+ 	
+ 	<insert id="insertScrap">
+ 		INSERT INTO SCRAP
+ 		VALUES (SCRAP_SEQ.NEXTVAL, #{param1}, 2, #{param2}, #{param3}, SYSDATE) 		
+ 	</insert>
+ 	
  	
 	<insert id="createMeeting" parameterType="String">
 		INSERT INTO MEETING

--- a/Project/src/main/java/com/koreait/project/yongsoo/dto/CreateNewMeetingDto.java
+++ b/Project/src/main/java/com/koreait/project/yongsoo/dto/CreateNewMeetingDto.java
@@ -1,6 +1,6 @@
 package com.koreait.project.yongsoo.dto;
 
-import java.sql.Timestamp;
+import java.sql.Date;
 
 import org.springframework.web.multipart.MultipartFile;
 
@@ -17,9 +17,9 @@ public class CreateNewMeetingDto {
 	private int user_no;
 	private String meeting_title;
 	private String meeting_content;
-	private Timestamp meeting_date;
-	private Timestamp start_gather_date;
-	private Timestamp end_gather_date;
+	private Date meeting_date;
+	private Date start_gather_date;
+	private Date end_gather_date;
 	private int meeting_max;
 	private int meeting_min;
 	private int exercise_no;

--- a/Project/src/main/java/com/koreait/project/yongsoo/dto/QnATemDto.java
+++ b/Project/src/main/java/com/koreait/project/yongsoo/dto/QnATemDto.java
@@ -1,6 +1,6 @@
 package com.koreait.project.yongsoo.dto;
 
-import java.sql.Timestamp;
+import java.sql.Date;
 
 import lombok.AllArgsConstructor;
 import lombok.Data;
@@ -16,11 +16,11 @@ public class QnATemDto {
 	private int trainer_user_no;
 	private String trainer_qna_title;
 	private String trainer_qna_content;
-	private Timestamp created_at;
+	private Date created_at;
 	private int is_published;	// 공개:0, 비공개:1
 	private int is_answered;	// 답변아직:0, 답변완료:1 
 	private String trainer_qna_answered;
-	private Timestamp answered_date;
+	private Date answered_date;
 	private int on_hide;	// 안숨김:0, 숨김:1 
 	
 	private String user_nickname;

--- a/Project/src/main/java/com/koreait/project/yongsoo/dto/ReviewTemDto.java
+++ b/Project/src/main/java/com/koreait/project/yongsoo/dto/ReviewTemDto.java
@@ -1,6 +1,6 @@
 package com.koreait.project.yongsoo.dto;
 
-import java.sql.Timestamp;
+import java.sql.Date;
 
 import lombok.AllArgsConstructor;
 import lombok.Data;
@@ -18,7 +18,7 @@ public class ReviewTemDto {
 	private int score;
 	private int meeting_no;
 	private String content;
-	private Timestamp created_at;
+	private Date created_at;
 	private int on_hide;
 	private int writer_user_no;
 	

--- a/Project/src/main/webapp/WEB-INF/views/yongPage/QnAPage/qnaUpdatePage.jsp
+++ b/Project/src/main/webapp/WEB-INF/views/yongPage/QnAPage/qnaUpdatePage.jsp
@@ -74,14 +74,14 @@
 </pre>
 <div id="qnaContent">
 	<span>질문 상세 내용</span>
+	<div style="color: darkgray;">텍스트를 입력하시려면 +버튼, 이미지를 첨부하시려면 사진버튼을 클릭해주세요~!</div>
+	<div id="content" style="border: 1px solid #d8d8d8;">${boardQnATemDto.board_qna_content}</div>
+	<br/>
 	<i class="far fa-plus-square btn" onclick="fn_addContent()"></i>
 	<label>
 		<input style="display: none" type="file" id="uploadFile" name="uploadFile" accept="image/*" />
 		<i class="far fa-images btn"></i>
 	</label>
-	<div style="text-align: right; color: darkgray;">텍스트를 입력하시려면 +버튼, 이미지를 첨부하시려면 사진버튼을 클릭해주세요~!</div>
-	<div id="content" style="border: 1px solid #d8d8d8;">${boardQnATemDto.board_qna_content}</div>
-	<br/>
 	<input type="button" id="doneBtn" value="수정완료" onclick="fn_updateQnA(this.form)" />
 	<input type="button" id="cancelBtn" value="수정취소" onclick="fn_goBack()" />
 </div>

--- a/Project/src/main/webapp/WEB-INF/views/yongPage/QnAPage/qnaViewPage.jsp
+++ b/Project/src/main/webapp/WEB-INF/views/yongPage/QnAPage/qnaViewPage.jsp
@@ -84,7 +84,11 @@
 						if(responseObj.result) {
 							Swal.fire('질문이 해결되었습니다.', '더 많은 정보들을 물어보세요!^^', 'success');
 							$('#writeComment').empty();
+							$('#writeComment').css('border', 'none');
 							$('#solveBtn').remove();
+							$('#deleteBtn').remove();
+							$('#updateBtn').remove();
+							$('#unsolved').text('[ 해결 완료 ]').css('color', 'green');
 						} else {
 							alert('해결완료가 안되었습니다.');
 						}
@@ -165,7 +169,7 @@
 					if (${qnaTemDto.is_resolved} == '0') {
 						$('#commentContent').empty();
 						$('#commentContent')
-						.append( $('<div>').html('작성된 comment가 없습니다. 첫번째 뎃글을 작성해주세요.') );	
+						.append( $('<div>').html('작성된 댓글이 없습니다.') );	
 					}
 				}
 			},
@@ -195,7 +199,7 @@
 		getQnACommentList();
 	}
 	
-	// 뎃글 작성 완료 버튼 클릭시 작동할 ajax함수
+	// 댓글 작성 완료 버튼 클릭시 작동할 ajax함수
 	function addQnAComment() {
 		$('#addComment').click(function(){
 			if ( '${loginUser.user_no}' == '' ) {
@@ -224,7 +228,7 @@
 							getQnACommentList();
 							document.getElementById("comment_content").value='';
 						} else {
-							alert('뎃글이 작성되지 않았습니다.');
+							alert('댓글이 작성되지 않았습니다.');
 						}
 					},
 					error: function(){alert('실패');}
@@ -320,11 +324,11 @@
 <c:if test="${loginUser.user_no ne null}">
 	<c:if test="${qnaTemDto.user_no eq loginUser.user_no}">
 		<form id="writerBtn">
-			<input type="button" value="수정하기" onclick="fn_goUpdate()" />
 			<c:if test="${qnaTemDto.is_resolved eq 0}">
 				<input type="button" id="solveBtn" value="해결완료" onclick="fn_solveQnA(${qnaTemDto.board_qna_no})" />
+				<input type="button" id="updateBtn" value="수정하기" onclick="fn_goUpdate()" />
+				<input type="button" id="deleteBtn" value="삭제하기" onclick="fn_deleteQnA()" />
 			</c:if>
-			<input type="button" value="삭제하기" onclick="fn_deleteQnA()" />
 		</form>
 	</c:if>		
 </c:if>
@@ -341,7 +345,15 @@
 	</colgroup>
 	<thead>
 		<tr>
-			<th colspan="3">${qnaTemDto.board_qna_title}</th>
+			<th colspan="3">
+				${qnaTemDto.board_qna_title}			
+				<c:if test="${qnaTemDto.is_resolved eq 1}">
+					<span style="color: green; font-size: 14px;">[ 해결 완료 ]</span>
+				</c:if>
+				<c:if test="${qnaTemDto.is_resolved eq 0}">
+					<span id="unsolved" style="color: red;  font-size: 14px;">[ 미 해결  ]</span>
+				</c:if>
+			</th>
 		</tr>	
 	</thead>
 	<tbody>
@@ -354,12 +366,6 @@
 				<c:if test="${qnaTemDto.user_separator eq 1}">트레이너</c:if>
 				<c:if test="${qnaTemDto.user_separator eq 2}">일반 회원</c:if>
 			</td>
-			<c:if test="${qnaTemDto.is_resolved eq 1}">
-				<td style="color: green;">해결 완료</td>
-			</c:if>
-			<c:if test="${qnaTemDto.is_resolved eq 0}">
-				<td style="color: red;">미 해결</td>
-			</c:if>
 		</tr>
 		<tr>
 			<td>${qnaTemDto.user_nickname}</td>

--- a/Project/src/main/webapp/WEB-INF/views/yongPage/QnAPage/totalQnAPage.jsp
+++ b/Project/src/main/webapp/WEB-INF/views/yongPage/QnAPage/totalQnAPage.jsp
@@ -84,11 +84,12 @@
 <div class="qnaTitle"> Total Question & Answer </div>
 
 <p id="newQnA">
-	<a href="#" onclick="fn_filter(2); return false;">전체 보기</a> 
-	/ <a href="#" onclick="fn_filter(1); return false;">해결 완료</a> 
-	/ <a href="#" onclick="fn_filter(0); return false;">미 해결</a>
+	<input type="button" onclick="fn_filter(2)" value="전체 보기"/> /
+	<input type="button" onclick="fn_filter(1)" value="해결 완료"/> /
+	<input type="button" onclick="fn_filter(0)" value="미 해결"/>
 	<input type="button" value="새 질문 등록하기" id="writeQnABtn" />
 </p>
+
 <table id="userQnA">
 	<colgroup>
 		<col width="60">
@@ -122,7 +123,7 @@
 					<c:if test="${list.is_resolved eq 1}">
 						<td style="color:green;">해결 완료</td>
 					</c:if>
-					<td><a href="goQnAViewPage.plitche?board_qna_no=${list.board_qna_no}&page=${page}">${list.board_qna_title}</a></td>
+					<td><a href="goQnAViewPage.plitche?board_qnapage_no=${list.board_qna_no}&page=${page}">${list.board_qna_title}</a></td>
 					<td>${list.user_nickname}</td>
 					<td>${list.created_at2}</td>
 				</tr>
@@ -149,8 +150,5 @@
 		<input id="searchBtn" type="button" value="검색" onclick="fn_search(this.form)" />
 	</p>
 </form>
-
-
-
 
 <%@ include file="../../template/footer.jsp" %>

--- a/Project/src/main/webapp/WEB-INF/views/yongPage/QnAPage/writeQnAPage.jsp
+++ b/Project/src/main/webapp/WEB-INF/views/yongPage/QnAPage/writeQnAPage.jsp
@@ -58,14 +58,14 @@
 </pre>
 <div id="qnaContent">
 	<span>질문 상세 내용</span>
+	<div style="color: darkgray;">텍스트를 입력하시려면 하단의 +버튼, 이미지를 첨부하시려면 사진버튼을 클릭해주세요~!</div>
+	<div id="content" style="border: 1px solid #d8d8d8;"></div>
+	<br/>
 	<i class="far fa-plus-square btn" onclick="fn_addContent()"></i>
 	<label>
 		<input style="display: none" type="file" id="uploadFile" name="uploadFile" accept="image/*" />
 		<i class="far fa-images btn"></i>
 	</label>
-	<div style="text-align: right; color: darkgray;">텍스트를 입력하시려면 +버튼, 이미지를 첨부하시려면 사진버튼을 클릭해주세요~!</div>
-	<div id="content" style="border: 1px solid #d8d8d8;"></div>
-	<br/>
 	<input type="button" id="doneBtn" value="질문 작성완료" onclick="fn_writeQnA(this.form)" />
 </div>
 

--- a/Project/src/main/webapp/WEB-INF/views/yongPage/trainerDetailPage.jsp
+++ b/Project/src/main/webapp/WEB-INF/views/yongPage/trainerDetailPage.jsp
@@ -84,8 +84,10 @@
 					$('#trainerMeetingFooter').html(meetingPagingHtml);
 					
 				} else {
-					$('<div>')
-					.append( $('<p>').html('등록된 모임 정보가 없습니다.') )
+					$('#totalMeeting').empty();
+					$('#totalMeeting').text('0');
+					
+					$('<div>').text('등록된 모임 정보가 없습니다.').css('text-align', 'center').css('margin-top', '20px').css('font-weight', 'bold')
 					.appendTo('#trainerMeetingList');
 				}
 			},
@@ -440,6 +442,9 @@
 					$('#qnaPaging').empty();
 					$('#qnaPaging').html(qnaPagingHtml);
 				} else {
+					$('#totalQnA').empty();
+					$('#totalQnA').text('0');
+					
 					$('<tr>')
 					.append( $('<td colspan="5">').html('등록된 질문이 없습니다. 첫 번째 질문을 등록해 주세요.') )
 					.appendTo('#qnaList');

--- a/Project/src/main/webapp/resources/style/soo/meetingViewPage.css
+++ b/Project/src/main/webapp/resources/style/soo/meetingViewPage.css
@@ -87,15 +87,19 @@
 .btns > input {
 	text-align: center;
 	padding: 13px 0;
-	border-radius: 999px;
-	background-color: #e73e26;
-	color: #fff;
+	border-radius: 5%;
+	background-color: #fff;
+	color: #000;
 	height: 40px;
 	font-weight: 700;
 	line-height: 15px;
 	width: 70px;
+	border: 1px solid #000;
 }
-
+.btns > input:hover {
+	color: orangered;
+	border: 1px solid orangered;
+}
 
 /* 호스트 관련 css */
 #host {
@@ -473,4 +477,7 @@
 	margin-top: 10px;
 	padding: 10px;
 }
-
+#wishList a {
+	color: red;
+	text-decoration: none;
+}

--- a/Project/src/main/webapp/resources/style/soo/qnaUpdatePage.css
+++ b/Project/src/main/webapp/resources/style/soo/qnaUpdatePage.css
@@ -58,13 +58,14 @@ h3 {
 }
 #doneBtn, #cancelBtn{
 	float: right;
-	border: none;
-	background: black;
-	color: white;
-	border-radius: 10%;
+	border: 1px solid #000;
+	background: #fff;
+	color: #000;
+	border-radius: 5%;
 	padding: 10px;
 	margin-left: 10px;
 }
 #doneBtn:hover, #cancelBtn:hover {
 	color: orangered;
+	border: 1px solid orangered;
 }

--- a/Project/src/main/webapp/resources/style/soo/qnaViewPage.css
+++ b/Project/src/main/webapp/resources/style/soo/qnaViewPage.css
@@ -10,10 +10,17 @@ h3 {
 
 
 #backToQnAList input {
-	background: #000;
-	color: white;
+	float: right;
+	border: 1px solid #000;
+	background: #fff;
+	color: #000;
 	border-radius: 5%;
 	padding: 5px;
+	margin-bottom: 10px;
+}
+#backToQnAList input:hover {
+	color: orangered;
+	border: 1px solid orangered;
 }
 #qnaDetail {
 	width: 100%;
@@ -74,12 +81,16 @@ h3 {
 	margin-bottom: auto;
 }
 #writerBtn input {
-	background: #000;
-	color: white;
+	border: 1px solid #000;
+	background: #fff;
+	color: #000;
 	border-radius: 5%;
 	padding: 5px;
 }
-
+#writerBtn input:hover {
+	color: orangered;
+	border: 1px solid orangered;
+}
 
 #comment {
 	margin-top: 50px;
@@ -166,8 +177,6 @@ h3 {
 	border: none;
 	background: none;
 }
-
-
 
 #commentPaging {
 	text-align: center;

--- a/Project/src/main/webapp/resources/style/soo/totalQnAPage.css
+++ b/Project/src/main/webapp/resources/style/soo/totalQnAPage.css
@@ -11,18 +11,28 @@
 }
 
 
-#newQnA a {
-	margin: 5px;
-	text-decoration: none;
-}
 #newQnA input {
-	border: none;
-	background: black;
-	color: white;
-	border-radius: 10%;
-	padding: 5px;
-	margin-left: 67%;
+	margin: 5px;
 }
+#newQnA input:nth-child(1),
+#newQnA input:nth-child(2),
+#newQnA input:nth-child(3) {
+	border: none;
+	background: none;
+}
+#newQnA input:nth-child(4) {
+	border: 1px solid #000;
+	background: #fff;
+	color: #000;
+	border-radius: 5%;
+	padding: 5px;
+	float: right;
+}
+#newQnA input:nth-child(4):hover {
+	color: orangered;
+	border: 1px solid orangered;	
+}
+
 #userQnA {
 	width: 100%;
 	border-collapse: collapse;
@@ -93,11 +103,18 @@ select option {
 	padding: 5px;
 }
 #searchBtn {
-	background: #000;
-	color: white;
+	background: #fff;
+	color: #000;
 	width: 56px;
 	height: 36px;
 	vertical-align: top;
-	border: none;
+	border: 1px solid #000;
 }
-
+#searchBtn:hover {
+	color: orangered;
+	border: 1px solid orangered;	
+}
+tfoot span {
+	color: orangered;
+	font-weight: bold;
+}

--- a/Project/src/main/webapp/resources/style/soo/trainerDetailPage.css
+++ b/Project/src/main/webapp/resources/style/soo/trainerDetailPage.css
@@ -61,14 +61,17 @@
 	text-align: center;
 	cursor: pointer;
 	font-weight: bold;
+	border: 1px solid gainsboro;
 	box-shadow: 3px 2px 2px darkgray;
 	border-bottom: 3px solid darkgray;
 }
-#tab ul li:hover, #tab ul li.on {
-	background: #000;
-	color: white;
+#tab ul li:hover {
 	border-bottom: 3px solid orangered;
 }
+ #tab ul li.on {
+ 	border-bottom: 3px solid orangered;
+ 	color: orangered;
+ }
 #tab .conBox {
 	width: 100%;
 	height: auto;
@@ -82,10 +85,16 @@
 
 /* 버튼들 css */
 .TrainerDetailBtn {
-	color: white;
-	background: #000;
+	color: #000;
+	background: #fff;
 	padding: 6px;
 	float: right;
+	border: 1px solid black;
+	border-radius: 5%;
+}
+.TrainerDetailBtn:hover{
+	color: orangered;
+	border: 1px solid orangered;
 }
 #openReviewModal, #openQnAModal {
 	margin-right: 4.5%;

--- a/Project/src/main/webapp/resources/style/soo/trainerDetailPage.js
+++ b/Project/src/main/webapp/resources/style/soo/trainerDetailPage.js
@@ -1,4 +1,0 @@
-/**
- * trainerDetailPage.jsp의 script 처리를 위한 파일
- */
-

--- a/Project/src/main/webapp/resources/style/soo/writeQnAPage.css
+++ b/Project/src/main/webapp/resources/style/soo/writeQnAPage.css
@@ -24,7 +24,6 @@ h3 {
 	border-radius: 5px;
 	border: 1px solid #ccc;
 }
-
 #writeRefer {
 	padding: 10px;
 	margin: 20px auto;
@@ -51,19 +50,20 @@ h3 {
 }
 #content {
 	border-radius: 5px;
-	min-height: 400px;
-	max-height: 800px;
+	min-height: 300px;
+	max-height: 600px;
 	overflow: scroll;
 	padding: 12px;
 }
 #doneBtn {
 	float: right;
-	border: none;
-	background: black;
-	color: white;
-	border-radius: 10%;
+	border: 1px solid #000;
+	background: #fff;
+	color: #000;
+	border-radius: 5%;
 	padding: 10px;
 }
 #doneBtn:hover {
 	color: orangered;
+	border: 1px solid orangered;
 }

--- a/Project/src/main/webapp/resources/style/style.css
+++ b/Project/src/main/webapp/resources/style/style.css
@@ -24,7 +24,7 @@ ul {
 
 .top-wrap {
 	width: 1080px;
-	margin: 10px auto;
+	margin: 0 auto;
 }
 .top-menu {
 	height: 60px;
@@ -42,7 +42,6 @@ ul {
 
 .top {
 	display: flex;
-	margin-left: 33%;
 }
 
 .top>li>a {
@@ -57,6 +56,7 @@ ul {
 
 .menu-bar {
 	display: flex;
+	margin-right: 32%;
 }
 
 .header {
@@ -97,8 +97,16 @@ ul {
 .introduce div:nth-child(1) span {
 	margin: -8px;
 }
-.introduce div:nth-child(1) span:nth-child(1):hover {color: blue; cursor: pointer;}
-
+.introduce div:nth-child(1) span:nth-child(1):hover {color: red;}
+.introduce div:nth-child(1) span:nth-child(2):hover {color: orangered;}
+.introduce div:nth-child(1) span:nth-child(3):hover {color: orange;}
+.introduce div:nth-child(1) span:nth-child(4):hover {color: yellow;}
+.introduce div:nth-child(1) span:nth-child(5):hover {color: limegreen;}
+.introduce div:nth-child(1) span:nth-child(6):hover {color: green;}
+.introduce div:nth-child(1) span:nth-child(7):hover {color: skyblue;}
+.introduce div:nth-child(1) span:nth-child(8):hover {color: blue;}
+.introduce div:nth-child(1) span:nth-child(9):hover {color: navy;}
+.introduce div:nth-child(1) span:nth-child(10):hover {color: purple;}
 
 .introduce div:nth-child(2) {
 	color: white;


### PR DESCRIPTION
1. 질의응답 게시판 해결완료/미해결 필터링 시 페이징 처리에 오류 수정 작업
2. 트레이너 list 페이지 평가점수가 double타입으로 나오던 부분 소수점 2자리까지 나오도록 작업
3. 모임 view페이지를 들어올 수 있는 경로가 트레이너detail과 커뮤니티list 두 군데에서 접근할 수 있기 때문에, 삭제 시 redirect할 mapping값을 정하기 위해 추가로 model에 어느 페이지에서 왔는지 저장해주는 작업
4. 모임 게시글 삭제 시 사용자가 왔던 경로로 돌아가게 해주는 작업 및 정호 controller와 연동
5. 메인 페이지 header css작업
6. 질의응답 / 트레이너 게시판 모든 버튼 부분 css작업
7. 질의응답 작성 시 택스트/이미지 버튼이 위에 있어서 불편했던 부분 아래로 수정
8. 질의응답 viewPage에서 해결 완료 처리 시 수정하기, 삭제하기 버튼도 같이 나오지 않도록 수정
9. 관심 모임 등록하기 scrap 관련 작업 실시
9-1. meetingview페이지로 이동 시 현재 로그인 여부에 따라, 로그인 한 사람이 이미 해당 모임을 scrap했는지 여부에 따라 아이콘을 다르게 표시 하도록 수정
9-2. 아직 scrap하지 않은 경우, 로그인 하지 않았다면 로그인 페이지로 이동. 로그인 한 상태라면 scrap테이블에 insert 해주기 위한 작업